### PR TITLE
Additional auto radius modes

### DIFF
--- a/Source/PCGExElementsZoneGraph/PCGExElementsZoneGraph.Build.cs
+++ b/Source/PCGExElementsZoneGraph/PCGExElementsZoneGraph.Build.cs
@@ -35,7 +35,7 @@ public class PCGExElementsZoneGraph : ModuleRules
 				"PCGExFoundations",
 				"PCGExGraphs",
 				"PCGExProperties",
-				"ZoneGraph",
+				"ZoneGraph", "PCGExtendedToolkit",
 			}
 		);
 

--- a/Source/PCGExElementsZoneGraph/Private/Graph/PCGExClusterToZoneGraph.cpp
+++ b/Source/PCGExElementsZoneGraph/Private/Graph/PCGExClusterToZoneGraph.cpp
@@ -35,7 +35,39 @@ namespace PCGExClusterToZoneGraph
 PCGExData::EIOInit UPCGExClusterToZoneGraphSettings::GetEdgeOutputInitMode() const { return PCGExData::EIOInit::Forward; }
 PCGExData::EIOInit UPCGExClusterToZoneGraphSettings::GetMainOutputInitMode() const { return PCGExData::EIOInit::Forward; }
 
+UPCGExClusterToZoneGraphSettings::UPCGExClusterToZoneGraphSettings()
+{
+	if (const UZoneGraphSettings* ZoneGraphSettings = GetDefault<UZoneGraphSettings>())
+	{
+		const TArray<FZoneLaneProfile>& Profiles = ZoneGraphSettings->GetLaneProfiles();
+		if (!Profiles.IsEmpty())
+		{
+			RoadSettings.LaneProfile = Profiles[0];
+		}
+	}
+}
+
 #if WITH_EDITOR
+void UPCGExClusterToZoneGraphSettings::ApplyDeprecation(UPCGNode* InOutNode)
+{
+	PCGEX_IF_VERSION_LOWER(1,75,14)
+	{
+		// Legacy *Min auto-radius modes are now (source, Min) tuples.
+		if (PolygonSettings.AutoRadiusMode == EPCGExZGAutoRadiusMode::WidestLaneMin)
+		{
+			PolygonSettings.AutoRadiusMode = EPCGExZGAutoRadiusMode::WidestLane;
+			PolygonSettings.AutoRadiusPolicy = EPCGExZGRadiusOverridePolicy::Min;
+		}
+		else if (PolygonSettings.AutoRadiusMode == EPCGExZGAutoRadiusMode::HalfProfileMin)
+		{
+			PolygonSettings.AutoRadiusMode = EPCGExZGAutoRadiusMode::HalfProfile;
+			PolygonSettings.AutoRadiusPolicy = EPCGExZGRadiusOverridePolicy::Min;
+		}
+	}
+	
+	Super::ApplyDeprecation(InOutNode);
+}
+
 void UPCGExClusterToZoneGraphSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
 {
 	RoadSettings.bCachedSupportsCustomLength = RoadSettings.bOverrideRoadPointType || RoadSettings.RoadPointType == FZoneShapePointType::Bezier;
@@ -561,7 +593,7 @@ namespace PCGExClusterToZoneGraph
 			// boundary is equivalent to trimming the S→B1 segment at the polygon boundary, so
 			// we keep the existing snap behavior here.
 			//
-			// End side: PrecomputedPoints.Last() is at Bn — an actual chain node, not the
+			// End side: PrecomputedPoints.Last() is at Bn -- an actual chain node, not the
 			// polygon center. Overwriting Bn with a position near S would skip Bn (and nearby
 			// nodes) from the spline whenever the loop is geometrically larger than the polygon
 			// radius. Instead, append a new crossing point on the implicit Bn→S wrap edge.
@@ -785,31 +817,72 @@ namespace PCGExClusterToZoneGraph
 		}
 		CachedLaneProfile = S->RoadSettings.LaneProfile;
 
-		// Compute per-road radii based on auto-radius mode
+		// Compute per-road radii: pick a per-road auto value from the source, then combine with manual radius via the policy.
 		CachedRoadRadii.SetNum(Roads.Num());
+
+		const EPCGExZGAutoRadiusMode Mode = S->PolygonSettings.AutoRadiusMode;
+		const EPCGExZGRadiusOverridePolicy Policy = S->PolygonSettings.AutoRadiusPolicy;
+
+		// Aggregate pre-pass: max-over-all-roads metrics, computed once for Max* modes.
+		double AggregateMaxLane = 0.0;
+		double AggregateMaxHalfProfile = 0.0;
+		if (Mode == EPCGExZGAutoRadiusMode::MaxWidestLane || Mode == EPCGExZGAutoRadiusMode::MaxHalfProfile)
+		{
+			for (const TSharedPtr<FZGRoad>& Road : Roads)
+			{
+				AggregateMaxLane = FMath::Max(AggregateMaxLane, Road->CachedMaxLaneWidth);
+				AggregateMaxHalfProfile = FMath::Max(AggregateMaxHalfProfile, Road->CachedTotalProfileWidth * 0.5);
+			}
+		}
+
 		for (int32 i = 0; i < Roads.Num(); i++)
 		{
 			double Radius = CachedRadius;
 
-			if (S->PolygonSettings.AutoRadiusMode != EPCGExZGAutoRadiusMode::Disabled)
+			if (Mode != EPCGExZGAutoRadiusMode::Disabled)
 			{
-				const double MaxLane = Roads[i]->CachedMaxLaneWidth;
-				const double HalfProfile = Roads[i]->CachedTotalProfileWidth * 0.5;
-
-				switch (S->PolygonSettings.AutoRadiusMode)
+				// 1) Resolve auto value from the selected source.
+				double AutoR = 0.0;
+				switch (Mode)
 				{
 				case EPCGExZGAutoRadiusMode::WidestLane:
-					Radius = MaxLane;
+					AutoR = Roads[i]->CachedMaxLaneWidth;
 					break;
 				case EPCGExZGAutoRadiusMode::HalfProfile:
-					Radius = HalfProfile;
+					AutoR = Roads[i]->CachedTotalProfileWidth * 0.5;
+					break;
+				case EPCGExZGAutoRadiusMode::MaxWidestLane:
+					AutoR = AggregateMaxLane;
+					break;
+				case EPCGExZGAutoRadiusMode::MaxHalfProfile:
+					AutoR = AggregateMaxHalfProfile;
+					break;
+				case EPCGExZGAutoRadiusMode::ConvexFit:
+					// Phase 2: replace with neighbor-derived per-road radius. Falls back to per-road half-profile until then.
+					AutoR = Roads[i]->CachedTotalProfileWidth * 0.5;
 					break;
 				case EPCGExZGAutoRadiusMode::WidestLaneMin:
-					Radius = FMath::Max(Radius, MaxLane);
-					break;
+					// Legacy slot -- should be migrated by ApplyDeprecation. Defensive: behave as (WidestLane, Min).
+					AutoR = Roads[i]->CachedMaxLaneWidth;
+					Radius = FMath::Max(Radius, AutoR);
+					CachedRoadRadii[i] = Radius;
+					continue;
 				case EPCGExZGAutoRadiusMode::HalfProfileMin:
-					Radius = FMath::Max(Radius, HalfProfile);
-					break;
+					// Legacy slot -- should be migrated by ApplyDeprecation. Defensive: behave as (HalfProfile, Min).
+					AutoR = Roads[i]->CachedTotalProfileWidth * 0.5;
+					Radius = FMath::Max(Radius, AutoR);
+					CachedRoadRadii[i] = Radius;
+					continue;
+				default: break;
+				}
+
+				// 2) Combine auto value with manual/attribute radius via policy.
+				switch (Policy)
+				{
+				case EPCGExZGRadiusOverridePolicy::Replace: Radius = AutoR; break;
+				case EPCGExZGRadiusOverridePolicy::Min:     Radius = FMath::Max(CachedRadius, AutoR); break;
+				case EPCGExZGRadiusOverridePolicy::Max:     Radius = FMath::Min(CachedRadius, AutoR); break;
+				case EPCGExZGRadiusOverridePolicy::Offset:  Radius = AutoR + CachedRadius; break;
 				default: break;
 				}
 			}
@@ -1187,7 +1260,7 @@ namespace PCGExClusterToZoneGraph
 			if (Chain->bIsClosedLoop)
 			{
 				// Non-roaming closed loop: wraps back to seed node. The binary "end" node is
-				// the last step before returning — not a real junction. Connect both road ends
+				// the last step before returning -- not a real junction. Connect both road ends
 				// to the seed polygon only.
 				const int32 SeedNode = Chain->Seed.Node;
 				TSharedPtr<FZGPolygon>* PolygonPtr = Map.Find(SeedNode);

--- a/Source/PCGExElementsZoneGraph/Private/Graph/PCGExClusterToZoneGraph.cpp
+++ b/Source/PCGExElementsZoneGraph/Private/Graph/PCGExClusterToZoneGraph.cpp
@@ -817,39 +817,60 @@ namespace PCGExClusterToZoneGraph
 		}
 		CachedLaneProfile = S->RoadSettings.LaneProfile;
 
-		// Compute per-road radii: pick a per-road auto value from the source, then combine with manual radius via the policy.
-		CachedRoadRadii.SetNum(Roads.Num());
+		const int32 NumRoads = Roads.Num();
+
+		// Pre-pass: outward road directions, half-widths, and polygon-wide aggregates — all in one sweep.
+		// RoadDirections is reused by the sort lambda and connection-point placement loop;
+		// HalfWidths feeds CachedPointHalfWidths and ConvexFit; aggregates feed the Max* modes.
+		TArray<FVector, TInlineAllocator<8>> RoadDirections;
+		TArray<double, TInlineAllocator<8>> HalfWidths;
+		RoadDirections.SetNumUninitialized(NumRoads);
+		HalfWidths.SetNumUninitialized(NumRoads);
+
+		double AggregateMaxLane = 0.0;
+		double AggregateMaxHalfProfile = 0.0;
+		double AggregateMinHalfProfile = TNumericLimits<double>::Max();
+
+		for (int32 i = 0; i < NumRoads; i++)
+		{
+			const TSharedPtr<FZGRoad>& Road = Roads[i];
+			const bool bExitSide = (FromStart[i] != Road->bIsReversed);
+			RoadDirections[i] = Road->Chain->GetOutwardDirAt(Cluster, NodeIndex, bExitSide);
+
+			const double Hw = Road->CachedTotalProfileWidth * 0.5;
+			HalfWidths[i] = Hw;
+			AggregateMinHalfProfile = FMath::Min(AggregateMinHalfProfile, Hw);
+			AggregateMaxHalfProfile = FMath::Max(AggregateMaxHalfProfile, Hw);
+			AggregateMaxLane = FMath::Max(AggregateMaxLane, Road->CachedMaxLaneWidth);
+		}
+
+		CachedRoadRadii.SetNum(NumRoads);
 
 		const EPCGExZGAutoRadiusMode Mode = S->PolygonSettings.AutoRadiusMode;
 		const EPCGExZGRadiusOverridePolicy Policy = S->PolygonSettings.AutoRadiusPolicy;
 
-		// Aggregate pre-pass: max-over-all-roads metrics, computed once for Max* modes.
-		double AggregateMaxLane = 0.0;
-		double AggregateMaxHalfProfile = 0.0;
-		if (Mode == EPCGExZGAutoRadiusMode::MaxWidestLane || Mode == EPCGExZGAutoRadiusMode::MaxHalfProfile)
+		TArray<double> ConvexFitRadii;
+		if (Mode == EPCGExZGAutoRadiusMode::ConvexFit)
 		{
-			for (const TSharedPtr<FZGRoad>& Road : Roads)
-			{
-				AggregateMaxLane = FMath::Max(AggregateMaxLane, Road->CachedMaxLaneWidth);
-				AggregateMaxHalfProfile = FMath::Max(AggregateMaxHalfProfile, Road->CachedTotalProfileWidth * 0.5);
-			}
+			ComputeConvexFitRadii(RoadDirections, HalfWidths, AggregateMinHalfProfile, AggregateMaxHalfProfile, ConvexFitRadii);
 		}
 
-		for (int32 i = 0; i < Roads.Num(); i++)
+		for (int32 i = 0; i < NumRoads; i++)
 		{
 			double Radius = CachedRadius;
 
 			if (Mode != EPCGExZGAutoRadiusMode::Disabled)
 			{
-				// 1) Resolve auto value from the selected source.
 				double AutoR = 0.0;
 				switch (Mode)
 				{
+				case EPCGExZGAutoRadiusMode::Disabled:
+					break;
 				case EPCGExZGAutoRadiusMode::WidestLane:
 					AutoR = Roads[i]->CachedMaxLaneWidth;
 					break;
 				case EPCGExZGAutoRadiusMode::HalfProfile:
-					AutoR = Roads[i]->CachedTotalProfileWidth * 0.5;
+					AutoR = HalfWidths[i];
 					break;
 				case EPCGExZGAutoRadiusMode::MaxWidestLane:
 					AutoR = AggregateMaxLane;
@@ -858,32 +879,19 @@ namespace PCGExClusterToZoneGraph
 					AutoR = AggregateMaxHalfProfile;
 					break;
 				case EPCGExZGAutoRadiusMode::ConvexFit:
-					// Phase 2: replace with neighbor-derived per-road radius. Falls back to per-road half-profile until then.
-					AutoR = Roads[i]->CachedTotalProfileWidth * 0.5;
+					AutoR = ConvexFitRadii[i];
 					break;
 				case EPCGExZGAutoRadiusMode::WidestLaneMin:
-					// Legacy slot -- should be migrated by ApplyDeprecation. Defensive: behave as (WidestLane, Min).
-					AutoR = Roads[i]->CachedMaxLaneWidth;
-					Radius = FMath::Max(Radius, AutoR);
-					CachedRoadRadii[i] = Radius;
-					continue;
 				case EPCGExZGAutoRadiusMode::HalfProfileMin:
-					// Legacy slot -- should be migrated by ApplyDeprecation. Defensive: behave as (HalfProfile, Min).
-					AutoR = Roads[i]->CachedTotalProfileWidth * 0.5;
-					Radius = FMath::Max(Radius, AutoR);
-					CachedRoadRadii[i] = Radius;
-					continue;
-				default: break;
+					break; // Migrated by ApplyDeprecation; never reached at runtime.
 				}
 
-				// 2) Combine auto value with manual/attribute radius via policy.
 				switch (Policy)
 				{
 				case EPCGExZGRadiusOverridePolicy::Replace: Radius = AutoR; break;
 				case EPCGExZGRadiusOverridePolicy::Min:     Radius = FMath::Max(CachedRadius, AutoR); break;
 				case EPCGExZGRadiusOverridePolicy::Max:     Radius = FMath::Min(CachedRadius, AutoR); break;
 				case EPCGExZGRadiusOverridePolicy::Offset:  Radius = AutoR + CachedRadius; break;
-				default: break;
 				}
 			}
 
@@ -895,37 +903,7 @@ namespace PCGExClusterToZoneGraph
 		Order.Sort(
 			[&](const int32 A, const int32 B)
 			{
-				const bool bSeedA = (NodeIndex == Roads[A]->Chain->Seed.Node);
-				const bool bEndA = (NodeIndex == Roads[A]->Chain->Links.Last().Node);
-				FVector DirA;
-				if (Roads[A]->Chain->bIsClosedLoop && bSeedA && !Roads[A]->Chain->Links.IsEmpty())
-				{
-					const bool bExitA = (FromStart[A] != Roads[A]->bIsReversed);
-					DirA = bExitA
-						? Cluster->GetDir(Roads[A]->Chain->Seed.Node, Roads[A]->Chain->Links[0].Node)
-						: Cluster->GetDir(Roads[A]->Chain->Seed.Node, Roads[A]->Chain->Links.Last().Node);
-				}
-				else
-				{
-					DirA = Roads[A]->Chain->GetEdgeDir(Cluster, (bSeedA && bEndA) ? FromStart[A] : bSeedA);
-				}
-
-				const bool bSeedB = (NodeIndex == Roads[B]->Chain->Seed.Node);
-				const bool bEndB = (NodeIndex == Roads[B]->Chain->Links.Last().Node);
-				FVector DirB;
-				if (Roads[B]->Chain->bIsClosedLoop && bSeedB && !Roads[B]->Chain->Links.IsEmpty())
-				{
-					const bool bExitB = (FromStart[B] != Roads[B]->bIsReversed);
-					DirB = bExitB
-						? Cluster->GetDir(Roads[B]->Chain->Seed.Node, Roads[B]->Chain->Links[0].Node)
-						: Cluster->GetDir(Roads[B]->Chain->Seed.Node, Roads[B]->Chain->Links.Last().Node);
-				}
-				else
-				{
-					DirB = Roads[B]->Chain->GetEdgeDir(Cluster, (bSeedB && bEndB) ? FromStart[B] : bSeedB);
-				}
-
-				return PCGExMath::GetRadiansBetweenVectors(DirA, FVector::ForwardVector) > PCGExMath::GetRadiansBetweenVectors(DirB, FVector::ForwardVector);
+				return PCGExMath::GetRadiansBetweenVectors(RoadDirections[A], FVector::ForwardVector) > PCGExMath::GetRadiansBetweenVectors(RoadDirections[B], FVector::ForwardVector);
 			});
 
 		PCGExArrayHelpers::InitArray(PrecomputedPoints, Order.Num());
@@ -936,25 +914,7 @@ namespace PCGExClusterToZoneGraph
 		{
 			const int32 Ri = Order[i];
 			const TSharedPtr<FZGRoad>& Road = Roads[Ri];
-			const bool bAtChainSeed = (NodeIndex == Road->Chain->Seed.Node);
-			const bool bAtChainEnd = (NodeIndex == Road->Chain->Links.Last().Node);
-
-			// For lollipop chains (single breakpoint on closed loop), seed==end node.
-			// Use FromStart to disambiguate: start connection → first edge dir, end connection → last edge dir.
-			// For self-connecting closed loops at seed polygon: Seed.Edge is overwritten to closing edge,
-			// so GetFirstEdgeDir gives wrong direction. Use Links[0].Node for exit, Links.Last() for entry.
-			FVector RoadDirection;
-			if (Road->Chain->bIsClosedLoop && bAtChainSeed && !Road->Chain->Links.IsEmpty())
-			{
-				const bool bIsExitSide = (FromStart[Ri] != Road->bIsReversed);
-				RoadDirection = bIsExitSide
-					? Cluster->GetDir(Road->Chain->Seed.Node, Road->Chain->Links[0].Node)
-					: Cluster->GetDir(Road->Chain->Seed.Node, Road->Chain->Links.Last().Node);
-			}
-			else
-			{
-				RoadDirection = Road->Chain->GetEdgeDir(Cluster, (bAtChainSeed && bAtChainEnd) ? FromStart[Ri] : bAtChainSeed);
-			}
+			const FVector& RoadDirection = RoadDirections[Ri];
 
 			// Store polygon boundary data on the road for precise intersection
 			FZGRoad::FPolygonEndpoint EP;
@@ -978,7 +938,49 @@ namespace PCGExClusterToZoneGraph
 
 			PrecomputedPoints[i] = ShapePoint;
 			CachedPointLaneProfiles[i] = Road->CachedLaneProfile;
-			CachedPointHalfWidths[i] = Road->CachedTotalProfileWidth * 0.5;
+			CachedPointHalfWidths[i] = HalfWidths[Ri];
+		}
+	}
+
+	void FZGPolygon::ComputeConvexFitRadii(
+		TArrayView<const FVector> InRoadDirections,
+		TArrayView<const double> InHalfWidths,
+		double InMinHalfProfile,
+		double InMaxHalfProfile,
+		TArray<double>& OutRadii) const
+	{
+		// r_i = max_j (hw_j / |sin(angle_ij)|): distance along d_i where each neighbor j's strip edge
+		// crosses d_i's centerline. hw_i (perpendicular to d_i) does not constrain r_i — when no
+		// neighbor constrains (collinear / dead-end), fall back to ConvexFitFallback to guarantee non-zero size.
+		const int32 N = InRoadDirections.Num();
+		OutRadii.SetNumUninitialized(N);
+
+		const FPCGExZGConvexFitSettings& CFS = Processor->GetSettings()->PolygonSettings.ConvexFitSettings;
+		constexpr double SinEpsilon = 1e-3;
+
+		const double HardCap = (InMaxHalfProfile > 0.0) ? CFS.Clamp * InMaxHalfProfile : 0.0;
+		const double FallbackValue = (CFS.Fallback == EPCGExZGConvexFitFallback::Smallest) ? InMinHalfProfile : InMaxHalfProfile;
+
+		for (int32 i = 0; i < N; i++)
+		{
+			double Ri = 0.0;
+			bool bAnyConstraint = false;
+
+			const FVector& Di = InRoadDirections[i];
+			for (int32 j = 0; j < N; j++)
+			{
+				if (j == i) { continue; }
+
+				const double SinTheta = FVector::CrossProduct(Di, InRoadDirections[j]).Size();
+				if (SinTheta < SinEpsilon) { continue; }
+
+				Ri = FMath::Max(Ri, InHalfWidths[j] / SinTheta);
+				bAnyConstraint = true;
+			}
+
+			if (!bAnyConstraint) { Ri = FallbackValue; }
+			if (HardCap > 0.0) { Ri = FMath::Min(Ri, HardCap); }
+			OutRadii[i] = Ri;
 		}
 	}
 

--- a/Source/PCGExElementsZoneGraph/Public/Graph/PCGExClusterToZoneGraph.h
+++ b/Source/PCGExElementsZoneGraph/Public/Graph/PCGExClusterToZoneGraph.h
@@ -18,7 +18,7 @@ UENUM(BlueprintType)
 enum class EPCGExZGOrientationMode : uint8
 {
 	SortDirection   = 0 UMETA(DisplayName="Sort Direction", Tooltip="Use the Direction Settings sorting rules to determine road orientation."),
-	DepthFirst      = 1 UMETA(DisplayName="Traffic Flow (Legacy)", Tooltip="Deprecated alias for Traffic Flow — kept for backward compatibility with saved assets."),
+	DepthFirst      = 1 UMETA(DisplayName="Traffic Flow (Legacy)", Tooltip="Deprecated alias for Traffic Flow -- kept for backward compatibility with saved assets."),
 	GlobalDirection = 2 UMETA(DisplayName="Global Direction", Tooltip="Orient all roads to flow along a global direction vector."),
 	TrafficFlow     = 3 UMETA(DisplayName="Traffic Flow", Tooltip="Propagate orientation from leaf nodes inward. Produces consistent lane direction at intersections and along loops. Isolated loops use the Orientation Direction vector as a CW/CCW hint."),
 };
@@ -27,10 +27,31 @@ UENUM(BlueprintType)
 enum class EPCGExZGAutoRadiusMode : uint8
 {
 	Disabled       = 0 UMETA(DisplayName="Disabled"),
-	WidestLane     = 1 UMETA(DisplayName="Widest Lane"),
-	HalfProfile    = 2 UMETA(DisplayName="Half Profile Width"),
-	WidestLaneMin  = 3 UMETA(DisplayName="Widest Lane (Min)"),
-	HalfProfileMin = 4 UMETA(DisplayName="Half Profile Width (Min)"),
+	WidestLane     = 1 UMETA(DisplayName="Widest Lane",       Tooltip="Per-road: each road's own widest lane width."),
+	HalfProfile    = 2 UMETA(DisplayName="Half Profile",      Tooltip="Per-road: each road's own profile half-width."),
+	
+#pragma region DEPRECATED
+	
+	// Legacy -- migrated by ApplyDeprecation to (WidestLane, Min)
+	
+	WidestLaneMin  = 3 UMETA(Hidden),	
+	HalfProfileMin = 4 UMETA(Hidden),
+	
+#pragma endregion 
+	
+	
+	MaxWidestLane  = 5 UMETA(DisplayName="Max Widest Lane",   Tooltip="Aggregate: max widest-lane across all roads, applied uniformly to the polygon."),
+	MaxHalfProfile = 6 UMETA(DisplayName="Max Half Profile",  Tooltip="Aggregate: max half-profile across all roads, applied uniformly to the polygon."),
+	ConvexFit      = 7 UMETA(DisplayName="Convex Fit",        Tooltip="Per-road radius geometrically fitted to clear neighboring roads' profile strips."),
+};
+
+UENUM(BlueprintType)
+enum class EPCGExZGRadiusOverridePolicy : uint8
+{
+	Replace = 0 UMETA(DisplayName="Replace",     Tooltip="Auto value replaces the manual/attribute radius."),
+	Min     = 1 UMETA(DisplayName="Use as Min",  Tooltip="radius = max(manual, auto). Auto acts as a floor."),
+	Max     = 2 UMETA(DisplayName="Use as Max",  Tooltip="radius = min(manual, auto). Auto acts as a ceiling."),
+	Offset  = 3 UMETA(DisplayName="Additive",    Tooltip="radius = auto + manual. Manual is a uniform additive buffer."),
 };
 
 UENUM(BlueprintType)
@@ -77,6 +98,10 @@ struct PCGEXELEMENTSZONEGRAPH_API FPCGExZGPolygonSettings
 	/** Auto-compute polygon radius from connected road lane profiles. */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings)
 	EPCGExZGAutoRadiusMode AutoRadiusMode = EPCGExZGAutoRadiusMode::Disabled;
+
+	/** How the auto-computed value combines with the manual / attribute polygon radius. */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(EditCondition="AutoRadiusMode != EPCGExZGAutoRadiusMode::Disabled", EditConditionHides))
+	EPCGExZGRadiusOverridePolicy AutoRadiusPolicy = EPCGExZGRadiusOverridePolicy::Replace;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(CategorySeparator="Routing"))
 	EZoneShapePolygonRoutingType PolygonRoutingType = EZoneShapePolygonRoutingType::Arcs;
@@ -227,20 +252,12 @@ class UPCGExClusterToZoneGraphSettings : public UPCGExClustersProcessorSettings
 	GENERATED_BODY()
 
 public:
-	UPCGExClusterToZoneGraphSettings()
-	{
-		if (const UZoneGraphSettings* ZoneGraphSettings = GetDefault<UZoneGraphSettings>())
-		{
-			const TArray<FZoneLaneProfile>& Profiles = ZoneGraphSettings->GetLaneProfiles();
-			if (!Profiles.IsEmpty())
-			{
-				RoadSettings.LaneProfile = Profiles[0];
-			}
-		}
-	}
-
+	UPCGExClusterToZoneGraphSettings();
+	
 	//~Begin UPCGSettings
 #if WITH_EDITOR
+	virtual void ApplyDeprecation(UPCGNode* InOutNode) override;
+	
 	PCGEX_NODE_INFOS(ClusterToZoneGraph, "Cluster to Zone Graph", "Create Zone Graph from clusters.");
 	virtual FLinearColor GetNodeTitleColor() const override { return GetDefault<UPCGExGlobalSettings>()->ColorClusterOp; }
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;

--- a/Source/PCGExElementsZoneGraph/Public/Graph/PCGExClusterToZoneGraph.h
+++ b/Source/PCGExElementsZoneGraph/Public/Graph/PCGExClusterToZoneGraph.h
@@ -55,6 +55,27 @@ enum class EPCGExZGRadiusOverridePolicy : uint8
 };
 
 UENUM(BlueprintType)
+enum class EPCGExZGConvexFitFallback : uint8
+{
+	Smallest = 0 UMETA(DisplayName="Smallest Profile", Tooltip="When no neighbor constrains a road's radius (e.g. dead-end, or chain-split with anti-parallel roads), fall back to the smallest profile half-width across all roads at the polygon. Guarantees a minimal non-zero polygon size."),
+	Largest  = 1 UMETA(DisplayName="Largest Profile",  Tooltip="When no neighbor constrains a road's radius, fall back to the largest profile half-width across all roads at the polygon. Produces a more generous polygon for transitions."),
+};
+
+USTRUCT(BlueprintType)
+struct PCGEXELEMENTSZONEGRAPH_API FPCGExZGConvexFitSettings
+{
+	GENERATED_BODY()
+
+	/** Cap for Convex Fit radii at acute-angle clusters. Per-road radius is clamped to this multiple of the largest profile half-width at the polygon. */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(ClampMin="1.0", UIMin="1.0"))
+	double Clamp = 4.0;
+
+	/** Fallback used by Convex Fit when no neighboring road constrains a road's radius (collinear / chain-split topologies). Computed before the override policy is applied. */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings)
+	EPCGExZGConvexFitFallback Fallback = EPCGExZGConvexFitFallback::Smallest;
+};
+
+UENUM(BlueprintType)
 enum class EPCGExZGTangentLengthMode : uint8
 {
 	Default    = 0 UMETA(DisplayName="Default", Tooltip="Don't set tangent length -- ZoneGraph handles it."),
@@ -102,6 +123,10 @@ struct PCGEXELEMENTSZONEGRAPH_API FPCGExZGPolygonSettings
 	/** How the auto-computed value combines with the manual / attribute polygon radius. */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(EditCondition="AutoRadiusMode != EPCGExZGAutoRadiusMode::Disabled", EditConditionHides))
 	EPCGExZGRadiusOverridePolicy AutoRadiusPolicy = EPCGExZGRadiusOverridePolicy::Replace;
+
+	/** Convex Fit refinement parameters (acute-angle clamp and fallback for unconstrained roads). */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(EditCondition="AutoRadiusMode == EPCGExZGAutoRadiusMode::ConvexFit", EditConditionHides, DisplayName="Convex Fit"))
+	FPCGExZGConvexFitSettings ConvexFitSettings;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(CategorySeparator="Routing"))
 	EZoneShapePolygonRoutingType PolygonRoutingType = EZoneShapePolygonRoutingType::Arcs;
@@ -452,6 +477,14 @@ namespace PCGExClusterToZoneGraph
 		void SyncRadiusToRoads();
 		void BuildPathOutput(const TSharedPtr<PCGExData::FPointIO>& InPathIO) const;
 		void Compile();
+
+	protected:
+		void ComputeConvexFitRadii(
+			TArrayView<const FVector> InRoadDirections,
+			TArrayView<const double> InHalfWidths,
+			double InMinHalfProfile,
+			double InMaxHalfProfile,
+			TArray<double>& OutRadii) const;
 	};
 
 	class FProcessor final : public PCGExClusterMT::TProcessor<FPCGExClusterToZoneGraphContext, UPCGExClusterToZoneGraphSettings>

--- a/Source/PCGExElementsZoneGraphEditor/Private/PCGExElementsZoneGraphEditor.cpp
+++ b/Source/PCGExElementsZoneGraphEditor/Private/PCGExElementsZoneGraphEditor.cpp
@@ -17,6 +17,7 @@ void FPCGExElementsZoneGraphEditorModule::StartupModule()
 
 	PCGEX_REGISTER_CUSTO("PCGExZGPolygonSettings", FPCGExZGSettingsCustomization)
 	PCGEX_REGISTER_CUSTO("PCGExZGRoadSettings", FPCGExZGSettingsCustomization)
+	PCGEX_REGISTER_CUSTO("PCGExZGConvexFitSettings", FPCGExZGConvexFitSettingsCustomization)
 
 	// ZoneGraph property types use the same compiled customization as core properties
 	PropertyModule.RegisterCustomPropertyTypeLayout(

--- a/Source/PCGExElementsZoneGraphEditor/Private/PCGExZGSettingsCustomization.cpp
+++ b/Source/PCGExElementsZoneGraphEditor/Private/PCGExZGSettingsCustomization.cpp
@@ -5,9 +5,11 @@
 
 #include "DetailWidgetRow.h"
 #include "IDetailChildrenBuilder.h"
+#include "Graph/PCGExClusterToZoneGraph.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Layout/SSeparator.h"
 #include "Widgets/Layout/SBox.h"
+#include "Widgets/SBoxPanel.h"
 
 #define LOCTEXT_NAMESPACE "PCGExZGSettingsCustomization"
 
@@ -58,6 +60,37 @@ void FPCGExZGSettingsCustomization::CustomizeChildren(
 
 		ChildBuilder.AddProperty(ChildHandle.ToSharedRef());
 	}
+}
+
+void FPCGExZGConvexFitSettingsCustomization::CustomizeHeader(
+	TSharedRef<IPropertyHandle> PropertyHandle,
+	FDetailWidgetRow& HeaderRow,
+	IPropertyTypeCustomizationUtils& CustomizationUtils)
+{
+	const TSharedPtr<IPropertyHandle> ClampHandle = PropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FPCGExZGConvexFitSettings, Clamp));
+	const TSharedPtr<IPropertyHandle> FallbackHandle = PropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FPCGExZGConvexFitSettings, Fallback));
+
+	HeaderRow
+	.NameContent()
+	[
+		PropertyHandle->CreatePropertyNameWidget()
+	]
+	.ValueContent()
+	.MinDesiredWidth(250.f)
+	[
+		SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot()
+		.FillWidth(0.4f)
+		.Padding(0, 0, 4, 0)
+		[
+			ClampHandle.IsValid() ? ClampHandle->CreatePropertyValueWidget() : SNullWidget::NullWidget
+		]
+		+ SHorizontalBox::Slot()
+		.FillWidth(0.6f)
+		[
+			FallbackHandle.IsValid() ? FallbackHandle->CreatePropertyValueWidget() : SNullWidget::NullWidget
+		]
+	];
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/PCGExElementsZoneGraphEditor/Private/PCGExZGSettingsCustomization.h
+++ b/Source/PCGExElementsZoneGraphEditor/Private/PCGExZGSettingsCustomization.h
@@ -24,3 +24,22 @@ public:
 		IDetailChildrenBuilder& ChildBuilder,
 		IPropertyTypeCustomizationUtils& CustomizationUtils) override;
 };
+
+class FPCGExZGConvexFitSettingsCustomization : public IPropertyTypeCustomization
+{
+public:
+	static TSharedRef<IPropertyTypeCustomization> MakeInstance()
+	{
+		return MakeShareable(new FPCGExZGConvexFitSettingsCustomization);
+	}
+
+	virtual void CustomizeHeader(
+		TSharedRef<IPropertyHandle> PropertyHandle,
+		FDetailWidgetRow& HeaderRow,
+		IPropertyTypeCustomizationUtils& CustomizationUtils) override;
+
+	virtual void CustomizeChildren(
+		TSharedRef<IPropertyHandle> PropertyHandle,
+		IDetailChildrenBuilder& ChildBuilder,
+		IPropertyTypeCustomizationUtils& CustomizationUtils) override {}
+};


### PR DESCRIPTION
Small refactor of auto-radius mode.
Behavior change : split the handling across two separate enum:
- reference value
- how to use radius value against that reference value
+ new Convex fit mode

NOTE : Requires PCGEx c89dda44868c0a3e793eddb0cb45ff551e8a210f (main) otherwise won't compile.